### PR TITLE
add gps metadata to photos (piexif) and video (ffmpeg)

### DIFF
--- a/SnapchatMemoriesCaptionAdder/_ffmpeg.py
+++ b/SnapchatMemoriesCaptionAdder/_ffmpeg.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from subprocess import Popen
 from typing import Optional
@@ -6,13 +7,15 @@ import ffmpeg
 
 from SnapchatMemoriesCaptionAdder.metadata import MediaType, Metadata
 
+logger = logging.getLogger("__snap")
+
 
 def ffmpeg_add_metadata(
-    base: Path,
-    overlay: Optional[Path],
-    metadata: Metadata,
-    output: Path,
-    quiet: bool = True,
+        base: Path,
+        overlay: Optional[Path],
+        metadata: Metadata,
+        output: Path,
+        quiet: bool = True,
 ) -> Optional[Popen]:
     """Use ffmpeg to add metadata to a video. Returns a Popen to the
     process running ffmpeg.
@@ -22,6 +25,29 @@ def ffmpeg_add_metadata(
 
     vid = ffmpeg.input(str(base))
     creation_time = f"creation_time={metadata.date.isoformat()}"
+    metadata_dict = {'metadata:g:0': creation_time}
+
+    if (metadata.location.latitude != 0) and (metadata.location.longitude != 0):
+        lat_string = '%.4f' % metadata.location.latitude
+        lon_string = '%.4f' % metadata.location.longitude
+        if metadata.location.latitude > 0:
+            lat_string = f"+{lat_string}"
+        if metadata.location.longitude > 0:
+            lon_string = f"+{lon_string}"
+
+        latlon_string = f"{lat_string}{lon_string}/"
+        location = f"location={latlon_string}"
+        location_eng = f"location-eng={latlon_string}"
+
+        # a hack to set multiple metadata values
+        # see https://github.com/kkroening/ffmpeg-python/issues/112#issuecomment-473682038
+        metadata_dict = {
+            'metadata:g:0': creation_time,
+            'metadata:g:1': location,
+            'metadata:g:2': location_eng
+        }
+    else:
+        logger.debug(f"Skipping location data for {str(output.name)} because the latitude and longitude are 0.")
 
     if overlay:
         overlay_img = ffmpeg.input(str(overlay))
@@ -33,11 +59,11 @@ def ffmpeg_add_metadata(
             overlay_video,  # video
             vid.audio,  # audio
             str(output),  # output file
-            metadata=creation_time,
+            **metadata_dict  # metadata hack
         ).run_async(quiet=quiet)
         return process
     else:
         # Don't run async! We just copy the video/audio over, it's very quick.
         # Async on the large ones
-        vid.output(str(output), codec="copy", metadata=creation_time).run(quiet=quiet)
+        vid.output(str(output), codec="copy", **metadata_dict).run(quiet=quiet)
         return None

--- a/SnapchatMemoriesCaptionAdder/_piexif.py
+++ b/SnapchatMemoriesCaptionAdder/_piexif.py
@@ -1,0 +1,91 @@
+import logging
+import piexif
+
+from fractions import Fraction
+from pathlib import Path
+
+from SnapchatMemoriesCaptionAdder.metadata import Metadata
+
+logger = logging.getLogger("__snap")
+
+
+def _deg_to_dms(decimal_coordinate, cardinal_directions):
+    """
+    This function converts decimal coordinates into the DMS (degrees, minutes and seconds) format.
+    It also determines the cardinal direction of the coordinates.
+
+    :param decimal_coordinate: the decimal coordinates, such as 34.0522
+    :param cardinal_directions: the locations of the decimal coordinate, such as ["S", "N"] or ["W", "E"]
+    :return: degrees, minutes, seconds and compass_direction
+    :rtype: int, int, float, string
+    """
+    if decimal_coordinate < 0:
+        compass_direction = cardinal_directions[0]
+    elif decimal_coordinate > 0:
+        compass_direction = cardinal_directions[1]
+    else:
+        compass_direction = ""
+    degrees = int(abs(decimal_coordinate))
+    decimal_minutes = (abs(decimal_coordinate) - degrees) * 60
+    minutes = int(decimal_minutes)
+    seconds = Fraction((decimal_minutes - minutes) * 60).limit_denominator(100)
+    return degrees, minutes, seconds, compass_direction
+
+
+def _dms_to_exif_format(dms_degrees, dms_minutes, dms_seconds):
+    """
+    This function converts DMS (degrees, minutes and seconds) to values that can
+    be used with the EXIF (Exchangeable Image File Format).
+
+    :param dms_degrees: int value for degrees
+    :param dms_minutes: int value for minutes
+    :param dms_seconds: fractions.Fraction value for seconds
+    :return: EXIF values for the provided DMS values
+    :rtype: nested tuple
+    """
+    exif_format = (
+        (dms_degrees, 1),
+        (dms_minutes, 1),
+        (int(dms_seconds.limit_denominator(100).numerator), int(dms_seconds.limit_denominator(100).denominator))
+    )
+    return exif_format
+
+
+def piexif_add_photo_location(path: Path, metadata: Metadata):
+    """Adds gps metadata (if any) to photo using pyexif."""
+
+    if metadata.location.latitude == 0 and metadata.location.longitude == 0:
+        logger.debug(f"Skipping location data for {str(path.name)} because the latitude and longitude are 0.")
+        return
+
+    # converts the latitude and longitude coordinates to DMS
+    latitude_dms = _deg_to_dms(metadata.location.latitude, ["S", "N"])
+    longitude_dms = _deg_to_dms(metadata.location.longitude, ["W", "E"])
+
+    # convert the DMS values to EXIF values
+    exif_latitude = _dms_to_exif_format(latitude_dms[0], latitude_dms[1], latitude_dms[2])
+    exif_longitude = _dms_to_exif_format(longitude_dms[0], longitude_dms[1], longitude_dms[2])
+
+    try:
+        # Load existing EXIF data
+        exif_data = piexif.load(str(path))
+
+        # https://exiftool.org/TagNames/GPS.html
+        # Create the GPS EXIF data
+        coordinates = {
+            piexif.GPSIFD.GPSVersionID: (2, 0, 0, 0),
+            piexif.GPSIFD.GPSLatitude: exif_latitude,
+            piexif.GPSIFD.GPSLatitudeRef: latitude_dms[3],
+            piexif.GPSIFD.GPSLongitude: exif_longitude,
+            piexif.GPSIFD.GPSLongitudeRef: longitude_dms[3]
+        }
+
+        # Update the EXIF data with the GPS information
+        exif_data['GPS'] = coordinates
+
+        # Dump the updated EXIF data and insert it into the image
+        exif_bytes = piexif.dump(exif_data)
+        piexif.insert(exif_bytes, str(path))
+        logger.debug(f"EXIF data updated successfully for the image {str(path.name)}.")
+    except Exception as e:
+        logger.warning(f"Error adding metadata to ${str(path.name)}: {str(e)}")

--- a/SnapchatMemoriesCaptionAdder/adder.py
+++ b/SnapchatMemoriesCaptionAdder/adder.py
@@ -8,6 +8,7 @@ from typing import Optional
 from dateutil.tz import tzlocal
 
 from SnapchatMemoriesCaptionAdder._ffmpeg import ffmpeg_add_metadata
+from SnapchatMemoriesCaptionAdder._piexif import piexif_add_photo_location
 from SnapchatMemoriesCaptionAdder._vips import vips_add_metadata
 from SnapchatMemoriesCaptionAdder.metadata import (
     MediaType,
@@ -88,6 +89,7 @@ def add_metadata(
     match metadata.type:
         case MediaType.Image:
             vips_add_metadata(base, overlay, metadata, output)
+            piexif_add_photo_location(output, metadata)
             process = None
         case MediaType.Video:
             process = ffmpeg_add_metadata(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+piexif >= 1.1.3
 python-dateutil >= 2.8.2
 pyvips >= 2.2.1
 ffmpeg-python >= 0.2.0


### PR DESCRIPTION
added GPS metadata for all media. i didn't test it exhaustively, but the metadata is the same as a couple of my devices use and appears with ffprobe and when uploaded to Google Photos, the location info appears and is accurate. no pressure to add!! just figured i'd share :)