### PR TITLE
Keep running when video fails to convert

### DIFF
--- a/SnapchatMemoriesCaptionAdder/_ffmpeg.py
+++ b/SnapchatMemoriesCaptionAdder/_ffmpeg.py
@@ -78,7 +78,7 @@ def ffmpeg_add_metadata(
                 output_node.run(quiet=quiet)
                 return None
         except ffmpeg.Error as err:
-            logger.error(f"ffmpeg error converting {base} with {overlay=}: {err=}")
+            logger.error(f"ffmpeg error converting {base.name} with overlay {overlay.name if overlay is not None else None}: {err=}")
             raise Exception(err)
     else:
         # Don't run async! We just copy the video/audio over, it's very quick.

--- a/SnapchatMemoriesCaptionAdder/adder.py
+++ b/SnapchatMemoriesCaptionAdder/adder.py
@@ -43,7 +43,9 @@ def add_metadata(
 
     Returns the created file, the handed in metadata because I'm too lazy to do
     this right, and if this was a video, the process running ffmpeg because
-    ffmpeg-python's async implementation is not asyncio"""
+    ffmpeg-python's async implementation is not asyncio
+
+    Raises an exception if ffmpeg fails to convert the video."""
 
     # First, get/validate paths, then prepare for merging
     root = memories_folder / (metadata.date.strftime("%Y-%m-%d_") + metadata.mid)

--- a/main.py
+++ b/main.py
@@ -121,10 +121,8 @@ def main():
 
     print("Done!")
     if len(video_failures) != 0:
-        print("Some videos failed to convert:")
-        for vid in video_failures:
-            print(vid.mid)
-        print("Please try running the command with the `-vv` flag to see why this video failed to convert. Submit a Github issue with the output if you don't know why it failed to convert.")
+        print("Some videos failed to convert. See the error logs above.")
+        print("Please try running the command with the `-vv` flag to see why these videos failed to convert. Submit a Github issue with the output if you don't know why it failed to convert.")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -123,7 +123,7 @@ def main():
     if len(video_failures) != 0:
         print("Some videos failed to convert:")
         for vid in video_failures:
-            print(vid.mid + ".mp4")
+            print(vid.mid)
         print("Please try running the command with the `-vv` flag to see why this video failed to convert. Submit a Github issue with the output if you don't know why it failed to convert.")
 
 

--- a/main.py
+++ b/main.py
@@ -77,15 +77,21 @@ def main():
             "(this will be slower than the pictures and will have hitches!)"
         )
         video_inputs = [vid for vid in parsed if vid.type == MediaType.Video]
+        video_failures = []
 
         for metadata in tqdm(video_inputs):
-            res = add_metadata(
-                args.memories_folder,
-                args.output_folder,
-                metadata,
-                ffmpeg_quiet=args.verbose != VerboseLevel.PROGRAM_AND_LIBRARIES,
-                ffmpeg_async=args.run_async
-            )
+            try:
+                res = add_metadata(
+                    args.memories_folder,
+                    args.output_folder,
+                    metadata,
+                    ffmpeg_quiet=args.verbose != VerboseLevel.PROGRAM_AND_LIBRARIES,
+                    ffmpeg_async=args.run_async,
+                )
+            except Exception:
+                video_failures.append(metadata)
+                continue
+
             if res is not None:
                 (path, metadata, process) = res
 
@@ -114,6 +120,11 @@ def main():
         add_file_creation(path, metadata)
 
     print("Done!")
+    if len(video_failures) != 0:
+        print("Some videos failed to convert:")
+        for vid in video_failures:
+            print(vid.mid + ".mp4")
+        print("Please try running the command with the `-vv` flag to see why this video failed to convert. Submit a Github issue with the output if you don't know why it failed to convert.")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -108,9 +108,10 @@ def main():
                 processes = [p for p in processes if p.poll() is None]
 
         # Wait on the final processes
-        print("Waiting for final videos...")
-        for process in tqdm(processes):
-            process.wait()
+        if len(processes) != 0:
+            print("Waiting for final videos...")
+            for process in tqdm(processes):
+                process.wait()
 
     # Okay, and now with all the files we can change their modification dates.
     # We used to do this in add_metadata! But since ffmpeg runs async now, the


### PR DESCRIPTION
Towards #11 / #20.

Log when a video fails to convert, but keep processing everything else. I have a feeling this will be a problem with *any* video with a caption, so this will prove or disprove that theory.